### PR TITLE
Update troubleshoot-service.yaml

### DIFF
--- a/demo-files/troubleshoot-service.yaml
+++ b/demo-files/troubleshoot-service.yaml
@@ -17,6 +17,8 @@ spec:
       containers:
       - image: nginx
         name: kplabs-service
+        ports:
+        - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
@@ -27,7 +29,7 @@ metadata:
 spec:
   ports:
   - port: 8080
-    targetPort: 8080
+    targetPort: 80
     protocol: TCP
   selector:
     run: kplabs-fix


### PR DESCRIPTION
nginx runs on default port 80 instead of 8080

landed here while solving the 2nd question from https://github.com/zealvora/certified-kubernetes-application-developer/blob/master/practice-tests/domain-3-networking.md